### PR TITLE
docs: add deprecated branch banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # repo
 
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/README.md
+
 Repo is a tool built on top of Git.  Repo helps manage many Git repositories,
 does the uploads to revision control systems, and automates parts of the
 development workflow.  Repo is not meant to replace Git, only to make it

--- a/SUBMITTING_PATCHES.md
+++ b/SUBMITTING_PATCHES.md
@@ -1,3 +1,6 @@
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/SUBMITTING_PATCHES.md
+
 [TOC]
 
 # Short Version

--- a/docs/internal-fs-layout.md
+++ b/docs/internal-fs-layout.md
@@ -1,5 +1,8 @@
 # Repo internal filesystem layout
 
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/docs/internal-fs-layout.md
+
 A reference to the `.repo/` tree in repo client checkouts.
 Hopefully it's complete & up-to-date, but who knows!
 

--- a/docs/manifest-format.md
+++ b/docs/manifest-format.md
@@ -1,5 +1,8 @@
 # repo Manifest Format
 
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/docs/manifest-format.md
+
 A repo manifest describes the structure of a repo client; that is
 the directories that are visible and where they should be obtained
 from with git.

--- a/docs/python-support.md
+++ b/docs/python-support.md
@@ -1,5 +1,8 @@
 # Supported Python Versions
 
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/docs/python-support.md
+
 With Python 2.7 officially going EOL on [01 Jan 2020](https://pythonclock.org/),
 we need a support plan for the repo project itself.
 Inevitably, there will be a long tail of users who still want to use Python 2 on

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,5 +1,8 @@
 # repo release process
 
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/docs/release-process.md
+
 This is the process for creating a new release of repo, as well as all the
 related topics and flows.
 

--- a/docs/repo-hooks.md
+++ b/docs/repo-hooks.md
@@ -1,5 +1,8 @@
 # repo hooks
 
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/docs/repo-hooks.md
+
 [TOC]
 
 Repo provides a mechanism to hook specific stages of the runtime with custom

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,5 +1,8 @@
 # Microsoft Windows Details
 
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/docs/windows.md
+
 Repo is primarily developed on Linux with a lot of users on macOS.
 Windows is, unfortunately, not a common platform.
 There is support in repo for Windows, but there might be some rough edges.

--- a/release/README.md
+++ b/release/README.md
@@ -1,2 +1,5 @@
+> **Warning: The "master" branch is no longer used.  Use "main" instead.**<br>
+> https://gerrit.googlesource.com/git-repo/+/HEAD/release/README.md
+
 These are helper tools for managing official releases.
 See the [release process](../docs/release-process.md) document for more details.


### PR DESCRIPTION
The master branch is dead.  Add banners to all the docs in case people try referring to these and don't realize they're on the wrong branch.

Change-Id: I3488d0d96df25fafd7285848fe9f519b4205519c
Reviewed-on: https://gerrit-review.googlesource.com/c/git-repo/+/400918
Tested-by: Mike Frysinger <vapier@google.com>
Reviewed-by: Josip Sokcevic <sokcevic@google.com>